### PR TITLE
Making histogram cumulative

### DIFF
--- a/src/histogram.ts
+++ b/src/histogram.ts
@@ -64,7 +64,6 @@ export class Histogram extends Metric {
         for (let i = 0; i < this.buckets.length; i++) {
             if (value <= this.buckets[i]) {
                 this.counters[i].inc();
-                return;
             }
         }
         this.counters.slice(-1)[0].inc();


### PR DESCRIPTION
The Histogram was not cumulative.

Upon adding logging to the first "Histogram" test we see that very clearly, the issue was that we were not iterating through all buckets to see if the observed value should increment that bucket, instead we were bailing after the first match.
```
ok (2008ms)
test invalid values ... ok (3ms)
test Counter.toString() ... ok (2ms)
test Histogram ... # TYPE http_request_duration histogram
http_request_duration_bucket{le="0.1"} 2
http_request_duration_bucket{le="0.2"} 0
http_request_duration_bucket{le="0.4"} 0
http_request_duration_bucket{le="0.6"} 0
http_request_duration_bucket{le="1"} 0
http_request_duration_bucket{le="3"} 0
http_request_duration_bucket{le="8"} 2
http_request_duration_bucket{le="20"} 0
http_request_duration_bucket{le="60"} 4
http_request_duration_bucket{le="120"} 0
http_request_duration_bucket{le="+Inf"} 2
http_request_duration_sum{} 810.11
http_request_duration_count{} 10
```